### PR TITLE
Added usage sub

### DIFF
--- a/itunes_backup2hashcat.pl
+++ b/itunes_backup2hashcat.pl
@@ -239,6 +239,11 @@ sub itunes_plist_get_hash
   return $hash;
 }
 
+sub usage
+{
+  print "Usage: $0 <Manifest.plist file>\n";
+}
+
 #
 # Start
 #


### PR DESCRIPTION
Fixes `undefined subroutine` problem.

```
$ ./itunes_backup2hashcat.pl
Undefined subroutine &main::usage called at ./itunes_backup2hashcat.pl line 248.
```